### PR TITLE
Remove mock from code coverage, GHA CI general refactor

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,13 +36,17 @@ jobs:
             target: safe-authd.exe
             output: safe-authd-x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache
@@ -82,13 +86,17 @@ jobs:
             target: x86_64-apple-darwin
             output: libsafe_ffi.dylib
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache
@@ -157,13 +165,17 @@ jobs:
       CSC_LINK: ${{ secrets.CSC_LINK }}
       CSC_IDENTITY_AUTO_DISCOVERY : true
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache
@@ -204,7 +216,7 @@ jobs:
         target: [armv7-linux-androideabi, x86_64-linux-android]
         component: [safe-ffi]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -212,6 +224,10 @@ jobs:
           profile: minimal
           override: true
           target: ${{ matrix.target }}
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache
@@ -286,7 +302,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
       DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust aarch64-apple-ios target
         uses: actions-rs/toolchain@v1
         with:
@@ -302,6 +318,10 @@ jobs:
           profile: minimal
           override: true
           target: x86_64-apple-ios
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache
@@ -356,7 +376,7 @@ jobs:
 
     steps:
       # Checkout and get all the artifacts built in the previous jobs.
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       # cli
       - name: Download safe-x86_64-pc-windows-msvc release
         uses: actions/download-artifact@master
@@ -562,7 +582,7 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - shell: bash
         id: commit_message
         run: |

--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -16,13 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     if: false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
       - run: mkdir -p ~/.safe/vault
       - name: dl vault
         run: wget https://github.com/maidsafe/safe_vault/releases/download/${{env.SAFE_VAULT_VERSION}}/safe_vault-${{env.SAFE_VAULT_VERSION}}-x86_64-unknown-linux-musl.zip
@@ -61,13 +62,14 @@ jobs:
     name: E2E against real baby with latest non-released vault
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
       - name: Clone safe-vault
         run: git clone https://github.com/maidsafe/safe-vault.git $HOME/.safe/vault
       - name: Build safe-vault

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Code Coverage - safe-api
         uses: actions-rs/tarpaulin@master
         with:
-          args: '-v --manifest-path=safe-api/Cargo.toml --features=scl-mock --exclude-files=safe-cli/*,jsonrpc-quic/*,safe-authd/*,safe-ffi/* --out Lcov -- --test-threads=1'
+          args: '-v --manifest-path=safe-api/Cargo.toml --exclude-files=safe-cli/*,jsonrpc-quic/*,safe-authd/*,safe-ffi/* --out Lcov -- --test-threads=1'
 
       # Push tarpaulin results to coveralls.io
       - name: Coveralls

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,3 +1,8 @@
+# PR workflow.
+#
+# Runs full suite of checks, with warnings treated as errors.
+# Gather code coverage stats and publish them on coveralls.io.
+
 name: PR
 
 on: [pull_request, push]
@@ -12,10 +17,10 @@ env:
 
 jobs:
   clippy:
-    name: Clippy, fmt & code coverage checks
+    name: Clippy & fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust and required components
         uses: actions-rs/toolchain@v1
         with:
@@ -24,9 +29,9 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      # Check if the code is formatted correctly.
-      - name: Check formatting
-        run: cargo fmt --all -- --check
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache
@@ -38,22 +43,56 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
+      # Check if the code is formatted correctly.
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
       # Run Clippy.
       - name: Clippy checks
         run: cargo clippy --all-targets --all-features
 
-      # Run cargo tarpaulin
-      - name: Code Coverage - safe-api
+  coverage:
+    name: Code coverage check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust and required components
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
+      # Run cargo tarpaulin & push result to coveralls.io
+      - name: rust-tarpaulin code coverage check
         uses: actions-rs/tarpaulin@master
         with:
-          args: '-v --manifest-path=safe-api/Cargo.toml --exclude-files=safe-cli/*,jsonrpc-quic/*,safe-authd/*,safe-ffi/* --out Lcov -- --test-threads=1'
-
-      # Push tarpaulin results to coveralls.io
-      - name: Coveralls
+          args: '-v --manifest-path=safe-api/Cargo.toml --release --exclude-files=safe-cli/*,jsonrpc-quic/*,safe-authd/*,safe-ffi/* --out Lcov'
+      - name: Push code coverage results to coveralls.io
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
           path-to-lcov: ./lcov.info
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
 
   build-ffi-android:
     name: Build FFI Android
@@ -63,7 +102,7 @@ jobs:
         target: [armv7-linux-androideabi, x86_64-linux-android]
         component: [safe-ffi]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -71,6 +110,10 @@ jobs:
           profile: minimal
           override: true
           target: ${{ matrix.target }}
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache
@@ -145,7 +188,7 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: 1
       DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust target aarch64-apple-ios
         uses: actions-rs/toolchain@v1
         with:
@@ -160,6 +203,10 @@ jobs:
           profile: minimal
           override: true
           target: x86_64-apple-ios
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache
@@ -214,13 +261,17 @@ jobs:
         shell: bash
         run: git config --global --add core.symlinks true
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -6,7 +6,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Do not merge until #591 has been resolved**, otherwise PR CI will fail

Note that the rust tarpaulin run currently fails CI due to failing safe-api tests when running against non-mock, as per issue being tracked [here](https://github.com/maidsafe/safe-api/issues/591).