### PR TITLE
chore(install): update script to account for `v` in version no

### DIFF
--- a/resources/install.sh
+++ b/resources/install.sh
@@ -15,7 +15,7 @@ sn_cli_install_dir() {
 }
 
 sn_cli_latest_version() {
-  curl -s https://api.github.com/repos/maidsafe/sn_api/releases/latest | grep -oP 'tag_name\": \"\K.*(?=\")'
+  curl -s https://api.github.com/repos/maidsafe/sn_api/releases/latest | grep -oP 'tag_name\": \"\K.*(?=\")' | sed 's/v//'
 }
 
 sn_cli_download() {


### PR DESCRIPTION
Version numbers now contain a v, e.g. `v0.15.0` so script not
expecting this. added a sed to strip out the v