### PR TITLE
fix(install): fix install script version grep cmd

### DIFF
--- a/resources/install.sh
+++ b/resources/install.sh
@@ -15,7 +15,7 @@ sn_cli_install_dir() {
 }
 
 sn_cli_latest_version() {
-  curl -s https://api.github.com/repos/maidsafe/sn_api/releases/latest | grep -oP 'tag_name\": \"\K.*(?=\")' | sed 's/v//'
+  curl -s "https://api.github.com/repos/maidsafe/sn_api/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/'
 }
 
 sn_cli_download() {


### PR DESCRIPTION
Reports on the forum that install script wasn't working on macOS. Updated the grep & tested on macOS & Ubuntu to make sure this change works fine. Don't have access to Windows at the moment.