### PR TITLE
Control self_update by a cargo feature

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    if: ${{ github.repository_owner == 'maidsafe' }}
+    # if: ${{ github.repository_owner == 'maidsafe' }}
     name: Build for benchmarking
     runs-on: ubuntu-latest
     if: false
@@ -40,7 +40,7 @@ jobs:
 
 
   benchmark:
-    if: ${{ github.repository_owner == 'maidsafe' }}
+    # if: ${{ github.repository_owner == 'maidsafe' }}
     name: Benchmarking ${{ matrix.benchmark }}
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Build for benchmarking
     runs-on: ubuntu-latest
     if: false
@@ -39,6 +40,7 @@ jobs:
 
 
   benchmark:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Benchmarking ${{ matrix.benchmark }}
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build-cli-authd:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Build Component
     runs-on: ${{ matrix.os }}
     strategy:
@@ -67,6 +68,7 @@ jobs:
 
   
   build-mac-cli-authd:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -133,6 +135,7 @@ jobs:
   # 'download-artifact' actions. We could perhaps implement our own 'retrieve all build artifacts'
   # action.
   deploy:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Deploy
     runs-on: ubuntu-latest
     needs: [build-cli-authd, build-mac-cli-authd]
@@ -282,6 +285,7 @@ jobs:
 
   # Automatic publish, triggered by a commit starting with "Version change".
   publish:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Publish
     needs: deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   network-test:
-    if: ${{ github.repository_owner == 'maidsafe' }}
+    # if: ${{ github.repository_owner == 'maidsafe' }}
     name: E2E against real baby
     runs-on: ubuntu-latest
     if: false

--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   network-test:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: E2E against real baby
     runs-on: ubuntu-latest
     if: false
@@ -58,6 +59,7 @@ jobs:
         run: tail $HOME/.safe/node/baby-fleming-nodes/*/*.log
 
   network-latest-node-test:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: E2E against real baby with latest non-released node
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
         run: cargo clippy --all-targets --all-features
 
   coverage:
-    if: ${{ github.repository_owner == 'maidsafe' }}
+    # if: ${{ github.repository_owner == 'maidsafe' }}
     name: Code coverage checks
     runs-on: ubuntu-latest
     if: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   clippy:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Clippy, fmt & code coverage checks
     runs-on: ubuntu-latest
     steps:
@@ -42,42 +43,44 @@ jobs:
         run: cargo clippy --all-targets --all-features
 
   coverage:
-      name: Code coverage checks
-      runs-on: ubuntu-latest
-      if: false
-      steps:
-        - uses: actions/checkout@v1
-        - name: Install Rust and required components
-          uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-            toolchain: stable
-            override: true
+    if: ${{ github.repository_owner == 'maidsafe' }}
+    name: Code coverage checks
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Rust and required components
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
-        # Cache.
-        - name: Cargo cache
-          uses: actions/cache@v2
-          with:
-            path: |
-              ~/.cargo/registry
-              ~/.cargo/git
-              target
-            key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+      # Cache.
+      - name: Cargo cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
-        # Run cargo tarpaulin
-        - name: Code Coverage - sn_api
-          uses: actions-rs/tarpaulin@master
-          with:
-            args: '-v --manifest-path=sn_api/Cargo.toml --exclude-files=sn_cli/*,qjsonrpc/*,sn_authd/* --out Lcov -- --test-threads=1'
+      # Run cargo tarpaulin
+      - name: Code Coverage - sn_api
+        uses: actions-rs/tarpaulin@master
+        with:
+          args: '-v --manifest-path=sn_api/Cargo.toml --exclude-files=sn_cli/*,qjsonrpc/*,sn_authd/* --out Lcov -- --test-threads=1'
 
-        # Push tarpaulin results to coveralls.io
-        - name: Coveralls
-          uses: coverallsapp/github-action@master
-          with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            path-to-lcov: ./lcov.info
+      # Push tarpaulin results to coveralls.io
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov.info
 
   test-component:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     name: Test Component
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -4,6 +4,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   audit:
+    if: ${{ github.repository_owner == 'maidsafe' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/sn_authd/Cargo.toml
+++ b/sn_authd/Cargo.toml
@@ -38,6 +38,7 @@ features = ["authenticator", "authd_client"]
 version = "~0.15.0"
 default-features = false
 features = ["rustls", "archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate"]
+optional = true
 
 [dev-dependencies.cargo-husky]
 version = "1"
@@ -45,5 +46,6 @@ default-features = false
 features = ["precommit-hook","user-hooks"]
 
 [features]
-default = ["simulated-payouts"]
+default = ["simulated-payouts", "self-update"]
 simulated-payouts = ["sn_api/simulated-payouts"]
+self-update = ["self_update"]

--- a/sn_authd/main.rs
+++ b/sn_authd/main.rs
@@ -26,9 +26,6 @@ use update::update_commander;
 #[macro_use]
 extern crate human_panic;
 
-#[macro_use]
-extern crate self_update;
-
 use operations::{restart_authd, start_authd, stop_authd};
 
 #[derive(StructOpt, Debug)]

--- a/sn_authd/requests/status.rs
+++ b/sn_authd/requests/status.rs
@@ -43,7 +43,7 @@ pub async fn process_req(
             notif_endpoints_list.len() as u32
         };
 
-        let authd_version = cargo_crate_version!().to_string();
+        let authd_version = env!("CARGO_PKG_VERSION").to_string();
 
         let status_report = AuthdStatus {
             safe_unlocked,

--- a/sn_authd/update.rs
+++ b/sn_authd/update.rs
@@ -96,7 +96,9 @@ fn set_exec_perms(file_path: PathBuf) -> Result<(), String> {
         .permissions();
 
     // set execution permissions bits for owner, group and others
-    perms.set_mode(perms.mode() | 0b0000_0100_1001);
+    // Allow unusual bit grouping to clearly separate 3 bits parts
+    #[allow(clippy::unusual_byte_groupings)]
+    perms.set_mode(perms.mode() | 0b0_001_001_001);
     file.set_permissions(perms).map_err(|err| {
         format!(
             "Failed to set execution permissions to installed binary '{}': {}",

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -26,7 +26,7 @@ pretty-hex = "~0.1.1"
 prettytable-rs = "~0.8"
 rand = "~0.7.3"
 relative-path = "~0.4.0"
-reqwest = { version = "~0.9.24", default-features=false, features = ["rustls-tls"] }
+reqwest = { version = "~0.9.24", default-features=false, features = ["rustls-tls"], optional = true }
 rpassword = "4.0.5"
 sn_launch_tool = "~0.0.5"
 serde = "1.0.91"
@@ -43,8 +43,9 @@ percent-encoding = "2.1.0"
 xor_name = "1"
 
 [features]
-default = ["simulated-payouts"]
+default = ["simulated-payouts", "self-update"]
 simulated-payouts = ["sn_api/simulated-payouts"]
+self-update = ["reqwest", "self_update"]
 
 
 [dependencies.sn_api]
@@ -56,6 +57,7 @@ features = ["app", "authd_client", "simulated-payouts"]
 version = "~0.15.0"
 default-features = false
 features = ["rustls", "archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate"]
+optional = true
 
 [dev-dependencies]
 anyhow = "1.0.36"

--- a/sn_cli/main.rs
+++ b/sn_cli/main.rs
@@ -22,9 +22,6 @@ extern crate prettytable;
 #[macro_use]
 extern crate human_panic;
 
-#[macro_use]
-extern crate self_update;
-
 const APP_ID: &str = "net.maidsafe.cli";
 #[allow(dead_code)]
 const APP_NAME: &str = "Safe CLI";

--- a/sn_cli/operations/config.rs
+++ b/sn_cli/operations/config.rs
@@ -240,21 +240,26 @@ pub fn retrieve_conn_info(name: &str, location: &str) -> Result<Vec<u8>, String>
         name, location
     );
     if is_remote_location(location) {
-        // Fetch info from an HTTP/s location
-        let mut resp = reqwest::get(location).map_err(|err| {
-            format!(
-                "Failed to fetch connection information for network '{}' from '{}': {}",
-                name, location, err
-            )
-        })?;
+        #[cfg(feature = "self-update")]
+        {
+            // Fetch info from an HTTP/s location
+            let mut resp = reqwest::get(location).map_err(|err| {
+                format!(
+                    "Failed to fetch connection information for network '{}' from '{}': {}",
+                    name, location, err
+                )
+            })?;
 
-        let conn_info = resp.text().map_err(|err| {
-            format!(
-                "Failed to fetch connection information for network '{}' from '{}': {}",
-                name, location, err
-            )
-        })?;
-        Ok(conn_info.as_bytes().to_vec())
+            let conn_info = resp.text().map_err(|err| {
+                format!(
+                    "Failed to fetch connection information for network '{}' from '{}': {}",
+                    name, location, err
+                )
+            })?;
+            Ok(conn_info.as_bytes().to_vec())
+        }
+        #[cfg(not(feature = "self-update"))]
+        Err("Self updates are disabled".to_string())
     } else {
         // Fetch it from a local file then
         let conn_info = fs::read(location).map_err(|err| {

--- a/sn_cli/operations/helpers.rs
+++ b/sn_cli/operations/helpers.rs
@@ -147,7 +147,9 @@ fn set_exec_perms(file_path: PathBuf) -> Result<(), String> {
         .permissions();
 
     // set execution permissions bits for owner, group and others
-    perms.set_mode(perms.mode() | 0b000_0100_1001);
+    // Allow unusual bit grouping to clearly separate 3 bits parts
+    #[allow(clippy::unusual_byte_groupings)]
+    perms.set_mode(perms.mode() | 0b0_001_001_001);
     file.set_permissions(perms).map_err(|err| {
         format!(
             "Failed to set execution permissions to installed binary '{}': {}",

--- a/sn_cli/operations/helpers.rs
+++ b/sn_cli/operations/helpers.rs
@@ -7,6 +7,8 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+#![cfg(feature = "self-update")]
+
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::PermissionsExt;
 use std::{

--- a/sn_cli/operations/node.rs
+++ b/sn_cli/operations/node.rs
@@ -7,6 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+#[cfg(feature = "self-update")]
 use super::helpers::download_from_s3_and_install_bin;
 use log::debug;
 use rand::distributions::Alphanumeric;
@@ -57,6 +58,12 @@ fn run_safe_cmd(
     Ok(())
 }
 
+#[cfg(not(feature = "self-update"))]
+pub fn node_install(_vault_path: Option<PathBuf>) -> Result<(), String> {
+    Err("Self updates are disabled".to_string())
+}
+
+#[cfg(feature = "self-update")]
 pub fn node_install(node_path: Option<PathBuf>) -> Result<(), String> {
     let target_path = get_node_bin_path(node_path)?;
     let _ = download_from_s3_and_install_bin(

--- a/sn_cli/subcommands/update.rs
+++ b/sn_cli/subcommands/update.rs
@@ -7,11 +7,20 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+#[cfg(feature = "self-update")]
 use log::debug;
 use std::error::Error;
 
+#[cfg(feature = "self-update")]
 const REPO_NAME: &str = "sn_api";
 
+#[cfg(not(feature = "self-update"))]
+pub fn update_commander() -> Result<(), Box<dyn Error>> {
+    println!("Self updates are disabled.");
+    Ok(())
+}
+
+#[cfg(feature = "self-update")]
 pub fn update_commander() -> Result<(), Box<dyn Error>> {
     let target = self_update::get_target();
     let releases = self_update::backends::github::ReleaseList::configure()
@@ -22,7 +31,7 @@ pub fn update_commander() -> Result<(), Box<dyn Error>> {
         .fetch()?;
 
     if releases.is_empty() {
-        println!("Current version is {}", cargo_crate_version!());
+        println!("Current version is {}", env!("CARGO_PKG_VERSION"));
         println!("No releases are available on GitHub to perform an update");
     } else {
         debug!("Found releases: {:#?}\n", releases);
@@ -37,7 +46,7 @@ pub fn update_commander() -> Result<(), Box<dyn Error>> {
             .target(&target)
             .bin_name(&bin_name)
             .show_download_progress(true)
-            .current_version(cargo_crate_version!())
+            .current_version(env!("CARGO_PKG_VERSION"))
             .build()?
             .update()?;
         println!("Update status: `{}`!", status.version());


### PR DESCRIPTION
Normally nothing changes for Maidsafe build process because self-update is an opt-out feature.

The procedure is a little more complex for user wanting to disable self-update feature:
```bash
cargo build -p sn_api --release
cd sn_cli/
cargo build --release --no-default-features --features "simulated-payouts"
cd ../sn_authd/
cargo build --release --no-default-features --features "simulated-payouts"
cd ..
```
Another possibility is to edit Cargo.toml file in sn_authd and sn_cli directories and remove self-update from default feature list:
```diff
sn_authd/Cargo.toml:

[features]
-default = ["simulated-payouts", "self-update"]
+default = ["simulated-payouts"]
simulated-payouts = ["sn_api/simulated-payouts"]
self-update = ["self_update"]

sn_cli/Cargo.toml:

[features]
-default = ["simulated-payouts", "self-update"]
+default = ["simulated-payouts"]
simulated-payouts = ["sn_api/simulated-payouts"]
self-update = ["reqwest", "self_update"]
```
And then just launch `cargo build --release`.

Disabling this feature is useful for user wanting to control the binaries they use, with no risk of being overwritten. Possible use cases:
- they want be sure of their integrity
- they have modified the code
- they have built a target not provided by Maidsafe

Additionally when self-update is disabled the crate doesn’t depend on openssl anymore which provides the following benefits:
- code can be compiled to MUSL targets
- major gain in executable size:

|  | With self-update | Without self-update | Gain | MUSL version | Gain |
|---|--:|--:|--:|--:|--:|
| safe | 31021920 | 22771952 | 27% | 21825984 | 30% |
| sn_authd | 21318280 | 16586400 | 22% | 15902848 | 25% |

Note also that I have removed macro_use of self_update in all cases, because I find ` env!("CARGO_PKG_VERSION"))` more explicit than `cargo_crate_version!()`.

And lastly, I did the same kind of modifications on GHA workflows which were accepted in qp2p and sn_node:
- Execute jobs only from Maidsafe repository
- Correct indentation in pr.yml

Another thing that is not friendly to user forking the repo is the pre-push hook (in .cargo-husk). It seems redundant with pr.yml and I let Maidsafe team think about removing it.