### PR TITLE
chore(cicd): update CI/CD to produce musl binary

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,11 +22,11 @@ jobs:
           - os: ubuntu-latest
             component: sn_cli
             target: safe
-            output: safe-x86_64-unknown-linux-gnu
+            output: safe-x86_64-unknown-linux-musl
           - os: ubuntu-latest
             component: sn_authd
             target: sn_authd
-            output: sn_authd-x86_64-unknown-linux-gnu
+            output: sn_authd-x86_64-unknown-linux-musl
           - os: windows-latest
             component: sn_cli
             target: safe.exe
@@ -54,8 +54,18 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
-      # Build
-      - name: Build
+      # Build on Ubuntu
+      - name: Build Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          sudo apt update -y && sudo apt install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml --target x86_64-unknown-linux-musl
+
+      # Build on Windows
+      - name: Build Windows
+        if: matrix.os == 'windows-latest'
         run: cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml
 
       # Upload
@@ -151,11 +161,11 @@ jobs:
         with:
           name: safe-x86_64-pc-windows-msvc
           path: artifacts/sn_cli/prod/x86_64-pc-windows-msvc/release
-      - name: Download safe-x86_64-unknown-linux-gnu release
+      - name: Download safe-x86_64-unknown-linux-musl release
         uses: actions/download-artifact@master
         with:
-          name: safe-x86_64-unknown-linux-gnu
-          path: artifacts/sn_cli/prod/x86_64-unknown-linux-gnu/release
+          name: safe-x86_64-unknown-linux-musl
+          path: artifacts/sn_cli/prod/x86_64-unknown-linux-musl/release
       - name: Download safe-x86_64-apple-darwin release
         uses: actions/download-artifact@master
         with:
@@ -168,18 +178,16 @@ jobs:
         with:
           name: sn_authd-x86_64-pc-windows-msvc
           path: artifacts/sn_authd/prod/x86_64-pc-windows-msvc/release
-      - name: Download sn_authd-x86_64-unknown-linux-gnu release
+      - name: Download sn_authd-x86_64-unknown-linux-musl release
         uses: actions/download-artifact@master
         with:
-          name: sn_authd-x86_64-unknown-linux-gnu
-          path: artifacts/sn_authd/prod/x86_64-unknown-linux-gnu/release
+          name: sn_authd-x86_64-unknown-linux-musl
+          path: artifacts/sn_authd/prod/x86_64-unknown-linux-musl/release
       - name: Download sn_authd-x86_64-apple-darwin release
         uses: actions/download-artifact@master
         with:
           name: sn_authd-x86_64-apple-darwin
           path: artifacts/sn_authd/prod/x86_64-apple-darwin/release
-
-
 
       # Get information for the release.
       - shell: bash
@@ -240,8 +248,8 @@ jobs:
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-gnu.zip
-          asset_name: sn_cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-gnu.zip
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-musl.zip
+          asset_name: sn_cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-musl.zip
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
       - uses: actions/upload-release-asset@v1.0.1
@@ -261,8 +269,8 @@ jobs:
       - uses: actions/upload-release-asset@v1.0.1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-gnu.tar.gz
-          asset_name: sn_cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-gnu.tar.gz
+          asset_path: deploy/prod/sn_cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-musl.tar.gz
+          asset_name: sn_cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-musl.tar.gz
           asset_content_type: application/zip
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
       - uses: actions/upload-release-asset@v1.0.1

--- a/resources/get_release_description.sh
+++ b/resources/get_release_description.sh
@@ -55,12 +55,12 @@ The Safe Authenticator, which runs as a daemon or as a service in Windows platfo
 * [Safe Network Node](https://github.com/maidsafe/sn_node/releases/latest/)
 EOF
 
-s3_authd_linux_deploy_url="https:\/\/sn-api.s3.amazonaws.com\/sn_authd-$authd_version-x86_64-unknown-linux-gnu.zip"
+s3_authd_linux_deploy_url="https:\/\/sn-api.s3.amazonaws.com\/sn_authd-$authd_version-x86_64-unknown-linux-musl.zip"
 s3_authd_win_deploy_url="https:\/\/sn-api.s3.amazonaws.com\/sn_authd-$authd_version-x86_64-pc-windows-msvc.zip"
 s3_authd_macos_deploy_url="https:\/\/sn-api.s3.amazonaws.com\/sn_authd-$authd_version-x86_64-apple-darwin.zip"
 
 zip_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$cli_version-x86_64-unknown-linux-gnu.zip" | \
+    "./deploy/prod/sn_cli-$cli_version-x86_64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 zip_macos_checksum=$(sha256sum \
     "./deploy/prod/sn_cli-$cli_version-x86_64-apple-darwin.zip" | \
@@ -69,7 +69,7 @@ zip_win_checksum=$(sha256sum \
     "./deploy/prod/sn_cli-$cli_version-x86_64-pc-windows-msvc.zip" | \
     awk '{ print $1 }')
 tar_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_cli-$cli_version-x86_64-unknown-linux-gnu.tar.gz" | \
+    "./deploy/prod/sn_cli-$cli_version-x86_64-unknown-linux-musl.tar.gz" | \
     awk '{ print $1 }')
 tar_macos_checksum=$(sha256sum \
     "./deploy/prod/sn_cli-$cli_version-x86_64-apple-darwin.tar.gz" | \
@@ -79,7 +79,7 @@ tar_win_checksum=$(sha256sum \
     awk '{ print $1 }')
 
 zip_authd_linux_checksum=$(sha256sum \
-    "./deploy/prod/sn_authd-$authd_version-x86_64-unknown-linux-gnu.zip" | \
+    "./deploy/prod/sn_authd-$authd_version-x86_64-unknown-linux-musl.zip" | \
     awk '{ print $1 }')
 zip_authd_macos_checksum=$(sha256sum \
     "./deploy/prod/sn_authd-$authd_version-x86_64-apple-darwin.zip" | \

--- a/resources/install.sh
+++ b/resources/install.sh
@@ -98,7 +98,7 @@ sn_cli_profile_is_bash_or_zsh() {
 }
 
 sn_cli_install() {
-  platform="unknown-linux-gnu"
+  platform="unknown-linux-musl"
   sn_cli_exec="safe"
   uname_output=$(uname -a)
   case $uname_output in

--- a/sn_cli/README.md
+++ b/sn_cli/README.md
@@ -46,6 +46,8 @@
       - [Wallet Insert](#wallet-insert)
       - [Wallet Transfer](#wallet-transfer)
     - [Files](#files)
+      - [[ Warning: Underlying API to be deprecated ]](#-warning-underlying-api-to-be-deprecated-)
+      - [Files...](#files-1)
       - [Files Put](#files-put)
         - [Base path of files in a FilesContainer](#base-path-of-files-in-a-filescontainer)
       - [Files Sync](#files-sync)
@@ -342,7 +344,7 @@ Downloading and installing the Authenticator daemon is very simple:
 ```shell
 $ safe auth install
 Latest release found: sn_authd v0.0.3
-Downloading https://sn-api.s3.eu-west-2.amazonaws.com/sn_authd-0.0.3-x86_64-unknown-linux-gnu.tar.gz...
+Downloading https://sn-api.s3.eu-west-2.amazonaws.com/sn_authd-0.0.3-x86_64-unknown-linux-musl.tar.gz...
 [00:00:25] [========================================] 6.16MB/6.16MB (0s) Done
 Installing sn_authd binary at ~/.safe/authd ...
 Setting execution permissions to installed binary '~/.safe/authd/sn_authd'...


### PR DESCRIPTION
Currently building gnu binary for Linux, switching to musl for greater compatibility.

Note that `install.sh` on S3 will need updated accordingly once a release with this code is triggered.