### PR TITLE
Ci update

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -69,8 +69,17 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml
 
-      # Upload
-      - name: Upload
+      # Upload Ubuntu
+      - name: Upload Ubuntu Builds
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ matrix.output }}
+          path: target/x86_64-unknown-linux-musl/release/${{ matrix.target }}
+      
+      # Upload Windows
+      - name: Upload Windows Builds
+        if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.output }}

--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -44,10 +44,15 @@ jobs:
           chmod +x $HOME/.safe/authd/sn_authd
           chmod +x $HOME/.safe/cli/safe
           chmod +x $HOME/.safe/node/sn_node
-      - name: Setup The Baby
+      - name: Setup The Network
         run : safe node run-baby-fleming -t
-      - name: Run Tests
+
+      - name: Run CLI Tests
         run: ./resources/test-scripts/cli-tests
+        shell: bash
+
+      - name: Run API Tests	
+        run: ./resources/test-scripts/api-tests	
         shell: bash
 
       - name: Stop the network.

--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -1,19 +1,19 @@
 name: Mini Network Tests
 
-on: [pull_request, push]
+on: [pull_request]
 
 env:
   # Run all cargo commands with --verbose.
   CARGO_TERM_VERBOSE: true
   RUST_BACKTRACE: 1
-  SN_NODE_VERSION: "0.24.0"
+  SN_NODE_VERSION: "latest"
   # Deny all compiler warnings.
   RUSTFLAGS: "-D warnings"
 
 jobs:
   network-test:
     # if: ${{ github.repository_owner == 'maidsafe' }}
-    name: E2E against real baby
+    name: E2E against real network
     runs-on: ubuntu-latest
     if: false
     steps:
@@ -26,7 +26,7 @@ jobs:
           override: true
       - run: mkdir -p ~/.safe/node
       - name: dl node
-        run: wget https://github.com/maidsafe/sn_node/releases/download/${{env.SN_NODE_VERSION}}/sn_node-${{env.SN_NODE_VERSION}}-x86_64-unknown-linux-musl.zip
+        run: wget "https://sn-node.s3.eu-west-2.amazonaws.com/sn_node-${{env.SN_NODE_VERSION}}-x86_64-unknown-linux-musl.zip"
       - run: unzip sn_node-${{env.SN_NODE_VERSION}}-x86_64-unknown-linux-musl.zip -d $HOME/.safe/node
       - name: Build
         run: cargo build --release
@@ -57,57 +57,3 @@ jobs:
       - name: Failure logs.
         if: failure()
         run: tail $HOME/.safe/node/baby-fleming-nodes/*/*.log
-
-  network-latest-node-test:
-    if: ${{ github.repository_owner == 'maidsafe' }}
-    name: E2E against real baby with latest non-released node
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Clone sn_node
-        run: git clone https://github.com/maidsafe/sn_node.git $HOME/.safe/node
-      - name: Build sn_node
-        run: cargo build --release --manifest-path=$HOME/.safe/node/Cargo.toml
-      - run: cp $HOME/.safe/node/target/release/sn_node $HOME/.safe/node/
-      - name: Build Safe CLI and sn_authd
-        run: cargo build --release
-      - name: Setup Safe CLI and PATH etc
-        run: |
-          mkdir -p ~/.safe/cli
-          mkdir -p ~/.safe/authd
-          cp ./target/release/safe $HOME/.safe/cli/
-          cp ./target/release/sn_authd $HOME/.safe/authd/
-          ls $HOME/.safe/cli
-          ls $HOME/.safe/authd
-          echo "$HOME/.safe/cli" >> $GITHUB_PATH
-          echo "$HOME/.safe/authd" >> $GITHUB_PATH
-          echo $PATH
-          chmod +x $HOME/.safe/authd/sn_authd
-          chmod +x $HOME/.safe/cli/safe
-          chmod +x $HOME/.safe/node/sn_node
-      - name: Setup The Baby
-        run : safe node run-baby-fleming -t
-      - name: Run CLI Tests
-        run: ./resources/test-scripts/cli-tests
-        shell: bash
-      - name: Run sn_api Tests
-        run: ./resources/test-scripts/api-tests
-        shell: bash
-
-      - name: Stop the network.
-        if: failure()
-        run: safe node killall || true && safe auth stop || true
-
-      - name: Failure sn_node logs.
-        if: failure()
-        run: tail $HOME/.safe/node/baby-fleming-nodes/*/*.log
-
-      - name: Failure sn_authd logs.
-        if: failure()
-        run: tail $HOME/.safe/authd/logs/sn_authd.log

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,7 +80,8 @@ jobs:
           path-to-lcov: ./lcov.info
 
   test-component:
-    if: ${{ github.repository_owner == 'maidsafe' }}
+    # if: ${{ github.repository_owner == 'maidsafe' }} // re-enable this once these tests are run again
+    if: false
     name: Test Component
     runs-on: ${{ matrix.os }}
     strategy:

--- a/resources/test-scripts/api-tests
+++ b/resources/test-scripts/api-tests
@@ -9,6 +9,4 @@ function run_api_tests() {
     cd -
 }
 
-# Temporarily disable running these tests as they currently
-# need refactoring to account for network sync up periods.
-# run_api_tests
+run_api_tests

--- a/resources/test-scripts/cli-tests
+++ b/resources/test-scripts/cli-tests
@@ -15,6 +15,4 @@ function run_cli_tests() {
     cd -
 }
 
-# Temporarily disable running these tests as they currently
-# need refactoring to account for network sync up periods.
-# run_cli_tests
+run_cli_tests


### PR DESCRIPTION
The node version to test against was explicitly stated in CI, meaning it would need
to be updated every time there was a new release. Easier to point
to "latest" which is stored on S3.
This PR also removes a now redundant check against latest master
node branch - with CD now in sn_node any merges to master are released
as "latest".

2nd commit fixes incorrect upload path for musl binaries and ensures disabled tests are only disabled in the CI scripts - this stops giving the impression that some disabled tests are passing.