### PR TITLE
Add `v` to generated tag and other CI maintenance

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -49,7 +49,7 @@ jobs:
       matrix:
         benchmark: [ keys, put ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - run: mkdir -p ~/.safe/node
       - name: dl node

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,7 +37,7 @@ jobs:
             target: sn_authd.exe
             output: sn_authd-x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -110,7 +110,7 @@ jobs:
       CSC_LINK: ${{ secrets.CSC_LINK }}
       CSC_IDENTITY_AUTO_DISCOVERY : true
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -166,7 +166,7 @@ jobs:
 
     steps:
       # Checkout and get all the artifacts built in the previous jobs.
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       # cli
       - name: Download safe-x86_64-pc-windows-msvc release
         uses: actions/download-artifact@master
@@ -307,7 +307,7 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - shell: bash
         id: commit_message
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -251,7 +251,7 @@ jobs:
       - uses: csexton/create-release@add-body
         id: create_release
         with:
-          tag_name: ${{ steps.versioning.outputs.cli_version }}
+          tag_name: v${{ steps.versioning.outputs.cli_version }}
           release_name: sn_cli
           draft: false
           prerelease: false

--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,10 +12,10 @@ env:
 jobs:
   clippy:
     if: ${{ github.repository_owner == 'maidsafe' }}
-    name: Clippy, fmt & code coverage checks
+    name: Clippy & fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust and required components
         uses: actions-rs/toolchain@v1
         with:
@@ -23,10 +23,6 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-
-      # Check if the code is formatted correctly.
-      - name: Check formatting
-        run: cargo fmt --all -- --check
 
       # Cache.
       - name: Cargo cache
@@ -38,6 +34,10 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
+      # Check if the code is formatted correctly.
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      
       # Run Clippy.
       - name: Clippy checks
         run: cargo clippy --all-targets --all-features
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     if: false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust and required components
         uses: actions-rs/toolchain@v1
         with:
@@ -70,7 +70,7 @@ jobs:
       - name: Code Coverage - sn_api
         uses: actions-rs/tarpaulin@master
         with:
-          args: '-v --manifest-path=sn_api/Cargo.toml --exclude-files=sn_cli/*,qjsonrpc/*,sn_authd/* --out Lcov -- --test-threads=1'
+          args: '-v --manifest-path=sn_api/Cargo.toml --release --exclude-files=sn_cli/*,qjsonrpc/*,sn_authd/* --out Lcov -- --test-threads=1'
 
       # Push tarpaulin results to coveralls.io
       - name: Coveralls
@@ -96,7 +96,7 @@ jobs:
         shell: bash
         run: git config --global --add core.symlinks true
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -7,7 +7,7 @@ jobs:
     if: ${{ github.repository_owner == 'maidsafe' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "sn_cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "ansi_term 0.9.0",
  "anyhow",


### PR DESCRIPTION
E.g. vx.x.x
This is what is expected by the install script, and it keeps this repo inline with others.