### PR TITLE
Typos

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           name: ${{ matrix.output }}
           path: target/x86_64-unknown-linux-musl/release/${{ matrix.target }}
-      
+
       # Upload Windows
       - name: Upload Windows Builds
         if: matrix.os == 'windows-latest'
@@ -85,7 +85,7 @@ jobs:
           name: ${{ matrix.output }}
           path: target/release/${{ matrix.target }}
 
-  
+
   build-mac-cli-authd:
     if: ${{ github.repository_owner == 'maidsafe' }}
     runs-on: ${{ matrix.os }}
@@ -246,7 +246,7 @@ jobs:
       # Upload all the release archives to S3;
       - name: Upload prod to S3
         run: aws s3 sync deploy/prod s3://sn-api --size-only --acl public-read
-     
+
       # Create the release and attach sn_cli archives as assets.
       - uses: csexton/create-release@add-body
         id: create_release

--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -51,8 +51,8 @@ jobs:
         run: ./resources/test-scripts/cli-tests
         shell: bash
 
-      - name: Run API Tests	
-        run: ./resources/test-scripts/api-tests	
+      - name: Run API Tests
+        run: ./resources/test-scripts/api-tests
         shell: bash
 
       - name: Stop the network.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
       # Check if the code is formatted correctly.
       - name: Check formatting
         run: cargo fmt --all -- --check
-      
+
       # Run Clippy.
       - name: Clippy checks
         run: cargo clippy --all-targets --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ All notable changes to this project will be documented in this file. See [standa
 ### Bug Fixes
 
 * ***api*** known issue in authorising CLI, as reported in last week's dev update, was solved: https://github.com/maidsafe/sn_api/pull/659
-  
+
 * ***cli*** fix `$ safe update` command as it was not looking up in the correct URL: https://github.com/maidsafe/sn_api/pull/660
 
 * ***cli*** install script had an issue for Mac users: https://github.com/maidsafe/sn_api/pull/661

--- a/sn_api/src/api/app/files.rs
+++ b/sn_api/src/api/app/files.rs
@@ -432,7 +432,7 @@ impl Safe {
         let xorurl_encoder = Safe::parse_url(url)?;
         if xorurl_encoder.content_version().is_some() {
             return Err(Error::InvalidInput(format!(
-                "The target URL cannot cannot contain a version: {}",
+                "The target URL cannot contain a version: {}",
                 url
             )));
         };
@@ -634,7 +634,7 @@ impl Safe {
         let xorurl_encoder = Safe::parse_url(url)?;
         if xorurl_encoder.content_version().is_some() {
             return Err(Error::InvalidInput(format!(
-                "The target URL cannot cannot contain a version: {}",
+                "The target URL cannot contain a version: {}",
                 url
             )));
         };
@@ -817,7 +817,7 @@ async fn validate_files_add_params(
     let xorurl_encoder = Safe::parse_url(url)?;
     if xorurl_encoder.content_version().is_some() {
         return Err(Error::InvalidInput(format!(
-            "The target URL cannot cannot contain a version: {}",
+            "The target URL cannot contain a version: {}",
             url
         )));
     };
@@ -2187,7 +2187,7 @@ mod tests {
                 assert_eq!(
                     err,
                     Error::InvalidInput(format!(
-                        "The target URL cannot cannot contain a version: {}",
+                        "The target URL cannot contain a version: {}",
                         versioned_xorurl
                     ))
                 );

--- a/sn_api/src/api/app/nrs.rs
+++ b/sn_api/src/api/app/nrs.rs
@@ -303,7 +303,7 @@ fn validate_nrs_name(name: &str) -> Result<(XorUrlEncoder, String)> {
     let xorurl_encoder = Safe::parse_url(&sanitised_url)?;
     if xorurl_encoder.content_version().is_some() {
         return Err(Error::InvalidInput(format!(
-            "The NRS name/subname URL cannot cannot contain a version: {}",
+            "The NRS name/subname URL cannot contain a version: {}",
             sanitised_url
         )));
     };
@@ -449,7 +449,7 @@ mod tests {
             Err(err) => assert_eq!(
                 err,
                 Error::InvalidInput(format!(
-                    "The NRS name/subname URL cannot cannot contain a version: {}",
+                    "The NRS name/subname URL cannot contain a version: {}",
                     versioned_sitename
                 ))
             ),
@@ -466,7 +466,7 @@ mod tests {
                 assert_eq!(
                     err,
                     Error::InvalidInput(format!(
-                        "The NRS name/subname URL cannot cannot contain a version: {}",
+                        "The NRS name/subname URL cannot contain a version: {}",
                         versioned_sitename
                     ))
                 );

--- a/sn_api/src/api/app/sequence.rs
+++ b/sn_api/src/api/app/sequence.rs
@@ -141,7 +141,7 @@ impl Safe {
         let xorurl_encoder = Safe::parse_url(url)?;
         if xorurl_encoder.content_version().is_some() {
             return Err(Error::InvalidInput(format!(
-                "The target URL cannot cannot contain a version: {}",
+                "The target URL cannot contain a version: {}",
                 url
             )));
         };

--- a/sn_cli/README-symlinks.md
+++ b/sn_cli/README-symlinks.md
@@ -119,7 +119,7 @@ returned, else an error will be generated.
 Windows since Vista supports native symlinks, however they are disabled by
 default. Writing symlinks to disk requires certain permissions (depends on the
 exact OS version), so `safe files get` may skip the symlink and issue a warning
-in this case. 
+in this case.
 
 Symlink support is enabled by choosing [run as
 administrator](https://www.howtogeek.com/howto/16226/complete-guide-to-symbolic-links-symlinks-on-windows-or-linux/)


### PR DESCRIPTION
Remove trailing spaces
Remove duplicate 'cannot cannot' from error message