### PR TITLE
Remove unused check for whitespace

### DIFF
--- a/sn_api/src/api/app/xorurl.rs
+++ b/sn_api/src/api/app/xorurl.rs
@@ -219,12 +219,6 @@ impl SafeUrlParts {
             return Err(Error::InvalidXorUrl(msg));
         }
 
-        // validate no spaces in name.
-        if public_name.find(' ').is_some() {
-            let msg = "name cannot contain a space".to_string();
-            return Err(Error::InvalidXorUrl(msg));
-        }
-
         // parse top_name and sub_names from name
         let names_vec: Vec<String> = public_name.split('.').map(String::from).collect();
         let top_name = names_vec[names_vec.len() - 1].to_string();


### PR DESCRIPTION
This is already done by Url::parse in host.rs#L96
https://github.com/servo/rust-url/blob/31bc0da54c659094dacb1434996f10ed1b46b5ae/url/src/host.rs#L96
which throws the error on host.rs#L113
Note the removed error message does not appear in any existing tests.