### PR TITLE
fix: remove short option used for dry run

### DIFF
--- a/sn_cli/subcommands/node.rs
+++ b/sn_cli/subcommands/node.rs
@@ -58,7 +58,7 @@ pub enum NodeSubCommands {
         #[structopt(short = "i", long, default_value = "1")]
         interval: u64,
         /// Number of nodes to be launched
-        #[structopt(short = "n", long = "nodes", default_value = "11")]
+        #[structopt(long = "nodes", default_value = "11")]
         num_of_nodes: u8,
         /// IP to be used to launch the local nodes.
         #[structopt(long = "ip")]


### PR DESCRIPTION
Running `cargo run` yielded the following:

```
thread 'main' panicked at 'Argument short must be unique

        -n is already in use', $HOME/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.3/src/app/parser.rs:193:13
```

Apparently the node subcommand was using `-n` (for number of nodes) as well as the global command (for dry running). I've solved it by omitting the short option in the node subcommand.