### PR TITLE
Update tiny-keccak from 1.5.0 to 2.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,7 +3676,7 @@ dependencies = [
  "sn_data_types",
  "thiserror",
  "threshold_crypto",
- "tiny-keccak 1.5.0",
+ "tiny-keccak 2.0.2",
  "tokio 0.2.25",
  "uhttp_uri",
  "url 2.2.0",
@@ -3751,7 +3751,6 @@ dependencies = [
  "sn_data_types",
  "sn_launch_tool",
  "structopt 0.3.21",
- "tiny-keccak 1.5.0",
  "tokio 0.2.25",
  "walkdir",
  "xor_name",
@@ -3804,7 +3803,7 @@ dependencies = [
  "serde_json",
  "sn_api",
  "sn_data_types",
- "tiny-keccak 1.5.0",
+ "tiny-keccak 2.0.2",
  "walkdir",
 ]
 

--- a/sn_api/Cargo.toml
+++ b/sn_api/Cargo.toml
@@ -32,7 +32,6 @@ serde = "1.0.91"
 serde_json = "1.0.41"
 thiserror = "1.0.23"
 threshold_crypto = "~0.4.0"
-tiny-keccak = "1.5.0"
 tokio = { version = "~0.2.21", features = ["rt-core"] }
 url = "2.1.1"
 urlencoding = "1.0.0"
@@ -42,6 +41,10 @@ xor_name = "1.1.1"
 pbkdf2 = { version = "~0.3.0", default-features = false }
 hmac = "~0.7.1"
 sha3 = "~0.8.2"
+
+  [dependencies.tiny-keccak]
+  version = "2.0.2"
+  features = [ "sha3" ]
 
 [features]
 authenticator = []

--- a/sn_api/src/api/app/xorurl.rs
+++ b/sn_api/src/api/app/xorurl.rs
@@ -17,7 +17,7 @@ use log::{debug, info, trace, warn};
 use multibase::{decode, encode, Base};
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use tiny_keccak::sha3_256;
+use tiny_keccak::{Hasher, Sha3};
 use uhttp_uri::HttpUri;
 use url::Url;
 use xor_name::{XorName, XOR_NAME_LEN}; // for parsing raw path
@@ -1390,7 +1390,11 @@ impl SafeUrl {
     }
 
     fn xor_name_from_nrs_string(name: &str) -> XorName {
-        let vec_hash = sha3_256(&name.to_string().into_bytes());
+        let name_bytes = name.as_bytes();
+        let mut hasher = Sha3::v256();
+        let mut vec_hash = [0; 32];
+        hasher.update(&name_bytes);
+        hasher.finalize(&mut vec_hash);
         let xor_name = XorName(vec_hash);
         debug!("Resulting XorName for NRS \"{}\" is: {}", name, xor_name);
         xor_name

--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -68,7 +68,6 @@ pretty_assertions = "~0.6.1"
 sn_data_types = "~0.14.3"
 criterion = "~0.3"
 walkdir = "2.3.1"
-tiny-keccak = "1.5.0"
 multibase = "~0.6.0"
 sn_cmd_test_utilities = { path = "../sn_cmd_test_utilities" }
 xor_name = "1"

--- a/sn_cmd_test_utilities/Cargo.toml
+++ b/sn_cmd_test_utilities/Cargo.toml
@@ -16,8 +16,11 @@ serde_json = "1.0.39"
 sn_data_types = "~0.14.3"
 duct = "~0.12.0"
 walkdir = "2.3.1"
-tiny-keccak = "1.5.0"
 multibase = "~0.6.0"
+
+  [dependencies.tiny-keccak]
+  version = "2.0.2"
+  features = [ "sha3" ]
 
 
 [dependencies.sn_api]

--- a/sn_cmd_test_utilities/src/lib.rs
+++ b/sn_cmd_test_utilities/src/lib.rs
@@ -15,7 +15,7 @@ use sn_api::{
     Keypair,
 };
 use std::{collections::BTreeMap, env, fs, path::Path, process};
-use tiny_keccak::sha3_256;
+use tiny_keccak::{Hasher, Sha3};
 use walkdir::{DirEntry, WalkDir};
 
 #[macro_use]
@@ -286,7 +286,11 @@ fn not_hidden_or_empty(entry: &DirEntry, max_depth: usize) -> bool {
 
 // returns sha3_256 hash of input string as a string.
 pub fn str_to_sha3_256(s: &str) -> String {
-    let bytes = sha3_256(&s.to_string().into_bytes());
+    let s_bytes = s.as_bytes();
+    let mut hasher = Sha3::v256();
+    let mut bytes = [0; 32];
+    hasher.update(&s_bytes);
+    hasher.finalize(&mut bytes);
     encode(Base::Base32, bytes)
 }
 


### PR DESCRIPTION
In sn_api the majority of dependencies use tiny-keccak 2.0.2 so it makes sense to have them all at the same version.

```
sn_api (master) $  cargo tree -i tiny-keccak:1.5.0
tiny-keccak v1.5.0
├── self_encryption v0.19.8
│   └── sn_client v0.46.2
│       └── sn_api v0.18.0 (/tmp/sn_api/sn_api)
│           ├── sn_authd v0.1.0 (/tmp/sn_api/sn_authd)
│           ├── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
│           └── sn_cmd_test_utilities v1.0.0 (/tmp/sn_api/sn_cmd_test_utilities)
│               [dev-dependencies]
│               └── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
├── sn_api v0.18.0 (/tmp/sn_api/sn_api) (*)
├── sn_client v0.46.2 (*)
├── sn_cmd_test_utilities v1.0.0 (/tmp/sn_api/sn_cmd_test_utilities) (*)
└── sn_data_types v0.14.3
    ├── sn_api v0.18.0 (/tmp/sn_api/sn_api) (*)
    ├── sn_client v0.46.2 (*)
    ├── sn_cmd_test_utilities v1.0.0 (/tmp/sn_api/sn_cmd_test_utilities) (*)
    ├── sn_messaging v3.0.0
    │   └── sn_client v0.46.2 (*)
    └── sn_transfers v0.3.1
        └── sn_client v0.46.2 (*)
    [dev-dependencies]
    └── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
[dev-dependencies]
└── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)

sn_api (master) $  cargo tree -i tiny-keccak:2.0.2
tiny-keccak v2.0.2
├── sn_messaging v3.0.0
│   └── sn_client v0.46.2
│       └── sn_api v0.18.0 (/tmp/sn_api/sn_api)
│           ├── sn_authd v0.1.0 (/tmp/sn_api/sn_authd)
│           ├── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
│           └── sn_cmd_test_utilities v1.0.0 (/tmp/sn_api/sn_cmd_test_utilities)
│               [dev-dependencies]
│               └── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
├── threshold_crypto v0.4.0
│   ├── sn_api v0.18.0 (/tmp/sn_api/sn_api) (*)
│   ├── sn_client v0.46.2 (*)
│   ├── sn_data_types v0.14.3
│   │   ├── sn_api v0.18.0 (/tmp/sn_api/sn_api) (*)
│   │   ├── sn_client v0.46.2 (*)
│   │   ├── sn_cmd_test_utilities v1.0.0 (/tmp/sn_api/sn_cmd_test_utilities) (*)
│   │   ├── sn_messaging v3.0.0 (*)
│   │   └── sn_transfers v0.3.1
│   │       └── sn_client v0.46.2 (*)
│   │   [dev-dependencies]
│   │   └── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
│   ├── sn_messaging v3.0.0 (*)
│   └── sn_transfers v0.3.1 (*)
└── xor_name v1.1.9
    ├── sn_api v0.18.0 (/tmp/sn_api/sn_api) (*)
    ├── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
    ├── sn_client v0.46.2 (*)
    ├── sn_data_types v0.14.3 (*)
    ├── sn_messaging v3.0.0 (*)
    └── sn_transfers v0.3.1 (*)
    [dev-dependencies]
    └── sn_cli v0.18.0 (/tmp/sn_api/sn_cli)
```