### PR TITLE
chore(clippy): adds clippy exception for unused result on windows

### DIFF
--- a/sn_authd/update.rs
+++ b/sn_authd/update.rs
@@ -63,6 +63,7 @@ pub fn update_commander() -> Result<(), Box<dyn (::std::error::Error)>> {
 }
 
 #[cfg(all(windows, feature = "self-update"))]
+#[allow(clippy::unnecessary_wraps)]
 #[inline]
 fn set_exec_perms(_file_path: PathBuf) -> Result<(), String> {
     // no need to set execution permissions on Windows

--- a/sn_cli/operations/helpers.rs
+++ b/sn_cli/operations/helpers.rs
@@ -103,6 +103,7 @@ fn download_and_install_bin(
 }
 
 #[cfg(target_os = "windows")]
+#[allow(clippy::unnecessary_wraps)]
 #[inline]
 fn set_exec_perms(_file_path: PathBuf) -> Result<()> {
     // no need to set execution permissions on Windows


### PR DESCRIPTION
Fixes #717 