### PR TITLE
feat: allow aliases of Safe (immutable references)

### DIFF
--- a/sn_api/src/api/app/fetch.rs
+++ b/sn_api/src/api/app/fetch.rs
@@ -799,7 +799,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_range_public_blob() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let saved_data = b"Something super immutable";
         let size = saved_data.len();
         let xorurl = safe
@@ -1012,7 +1012,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_public_blob_with_path() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let data = b"Something super immutable";
         let xorurl = safe.files_store_public_blob(data, None, false).await?;
 

--- a/sn_api/src/api/app/fetch.rs
+++ b/sn_api/src/api/app/fetch.rs
@@ -201,7 +201,7 @@ impl Safe {
     // An optional 'while_is' argment can be set as a filter to stop reslution process
     // upon the first non-matching content type.
     pub(crate) async fn retrieve_from_url(
-        &mut self,
+        &self,
         url: &str,
         retrieve_data: bool,
         range: Range,
@@ -243,7 +243,7 @@ impl Safe {
     }
 
     async fn resolve_one_indirection(
-        &mut self,
+        &self,
         mut the_xor: SafeUrl,
         metadata: Option<FileItem>,
         retrieve_data: bool,
@@ -506,7 +506,7 @@ impl Safe {
     }
 
     async fn retrieve_blob(
-        &mut self,
+        &self,
         the_xor: &SafeUrl,
         retrieve_data: bool,
         media_type: Option<String>,

--- a/sn_api/src/api/app/fetch.rs
+++ b/sn_api/src/api/app/fetch.rs
@@ -145,7 +145,7 @@ impl Safe {
     ///     assert!(data_string.starts_with("hello tests!"));
     /// # });
     /// ```
-    pub async fn fetch(&mut self, url: &str, range: Range) -> Result<SafeData> {
+    pub async fn fetch(&self, url: &str, range: Range) -> Result<SafeData> {
         let mut resolution_chain = self.retrieve_from_url(url, true, range, true).await?;
         // Construct return data using the last and first items from the resolution chain
         resolution_chain

--- a/sn_api/src/api/app/files/mod.rs
+++ b/sn_api/src/api/app/files/mod.rs
@@ -538,7 +538,7 @@ impl Safe {
     /// # });
     /// ```
     pub async fn files_store_public_blob(
-        &mut self,
+        &self,
         data: &[u8],
         media_type: Option<&str>,
         dry_run: bool,

--- a/sn_api/src/api/app/files/mod.rs
+++ b/sn_api/src/api/app/files/mod.rs
@@ -143,7 +143,7 @@ impl Safe {
 
     /// Fetch a FilesContainer from a SafeUrl without performing any type of URL resolution
     pub(crate) async fn fetch_files_container(
-        &mut self,
+        &self,
         safe_url: &SafeUrl,
     ) -> Result<(u64, FilesMap)> {
         // Check if the URL specifies a specific version of the content or simply the latest available
@@ -586,7 +586,7 @@ impl Safe {
 
     /// Fetch an Blob from a SafeUrl without performing any type of URL resolution
     pub(crate) async fn fetch_public_blob(
-        &mut self,
+        &self,
         safe_url: &SafeUrl,
         range: Range,
     ) -> Result<Vec<u8>> {

--- a/sn_api/src/api/app/keys.rs
+++ b/sn_api/src/api/app/keys.rs
@@ -28,10 +28,7 @@ impl Safe {
 
     // Create a SafeKey allocating token from current client's key onto it,
     // and return the SafeKey's XOR-URL
-    pub async fn keys_create_and_preload(
-        &self,
-        preload_amount: &str,
-    ) -> Result<(String, Keypair)> {
+    pub async fn keys_create_and_preload(&self, preload_amount: &str) -> Result<(String, Keypair)> {
         let amount = parse_coins_amount(preload_amount)?;
         let new_keypair = self.generate_random_ed_keypair();
 
@@ -113,21 +110,13 @@ impl Safe {
     // Check SafeKey's balance from the network from a given XOR/NRS-URL and secret key string.
     // The difference between this and 'keys_balance_from_sk' function is that this will additionally
     // check that the XOR/NRS-URL corresponds to the public key derived from the provided secret key
-    pub async fn keys_balance_from_url(
-        &self,
-        url: &str,
-        secret_key: SecretKey,
-    ) -> Result<String> {
+    pub async fn keys_balance_from_url(&self, url: &str, secret_key: SecretKey) -> Result<String> {
         self.validate_sk_for_url(&secret_key, url).await?;
         self.keys_balance_from_sk(secret_key).await
     }
 
     // Check that the XOR/NRS-URL corresponds to the public key derived from the provided client id
-    pub async fn validate_sk_for_url(
-        &self,
-        secret_key: &SecretKey,
-        url: &str,
-    ) -> Result<String> {
+    pub async fn validate_sk_for_url(&self, secret_key: &SecretKey, url: &str) -> Result<String> {
         let derived_xorname = match secret_key {
             SecretKey::Ed25519(sk) => {
                 let pk: ed25519_dalek::PublicKey = sk.into();

--- a/sn_api/src/api/app/keys.rs
+++ b/sn_api/src/api/app/keys.rs
@@ -29,7 +29,7 @@ impl Safe {
     // Create a SafeKey allocating token from current client's key onto it,
     // and return the SafeKey's XOR-URL
     pub async fn keys_create_and_preload(
-        &mut self,
+        &self,
         preload_amount: &str,
     ) -> Result<(String, Keypair)> {
         let amount = parse_coins_amount(preload_amount)?;
@@ -49,7 +49,7 @@ impl Safe {
 
     // Create a SafeKey preloaded from another key and return its XOR-URL.
     pub async fn keys_create_and_preload_from_sk_string(
-        &mut self,
+        &self,
         from: &str,
         preload_amount: &str,
     ) -> Result<(String, Keypair)> {
@@ -79,7 +79,7 @@ impl Safe {
     #[cfg(feature = "simulated-payouts")]
     // Create a SafeKey on the network, allocates testcoins onto it, and return the SafeKey's XOR-URL
     pub async fn keys_create_preload_test_coins(
-        &mut self,
+        &self,
         preload_amount: &str,
     ) -> Result<(String, Keypair)> {
         let amount = parse_coins_amount(preload_amount)?;
@@ -114,7 +114,7 @@ impl Safe {
     // The difference between this and 'keys_balance_from_sk' function is that this will additionally
     // check that the XOR/NRS-URL corresponds to the public key derived from the provided secret key
     pub async fn keys_balance_from_url(
-        &mut self,
+        &self,
         url: &str,
         secret_key: SecretKey,
     ) -> Result<String> {
@@ -124,7 +124,7 @@ impl Safe {
 
     // Check that the XOR/NRS-URL corresponds to the public key derived from the provided client id
     pub async fn validate_sk_for_url(
-        &mut self,
+        &self,
         secret_key: &SecretKey,
         url: &str,
     ) -> Result<String> {
@@ -174,7 +174,7 @@ impl Safe {
     /// # });
     /// ```
     pub async fn keys_transfer(
-        &mut self,
+        &self,
         amount: &str,
         from_sk_str: Option<&str>,
         to: &str,
@@ -221,7 +221,7 @@ impl Safe {
     }
 
     async fn transfer_to_url(
-        &mut self,
+        &self,
         from: Option<Keypair>,
         to: &str,
         amount_coins: Token,
@@ -271,14 +271,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_create_preload_test_coins() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let _ = safe.keys_create_preload_test_coins("12.23").await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn test_keys_create_and_preload_from_sk_string() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let (_, from_keypair) = safe.keys_create_preload_test_coins("543.2312").await?;
         let from_sk_hex = sk_to_hex(from_keypair.secret_key()?);
 
@@ -293,7 +293,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_create_preload_invalid_amounts() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         match safe.keys_create_preload_test_coins(".45").await {
             Ok(_) => {
                 bail!("Key with test-coins was created unexpectedly".to_string(),)
@@ -363,7 +363,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_create_pk() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let (_, from_keypair) = safe.keys_create_preload_test_coins("1.1").await?;
         let from_sk_hex = sk_to_hex(from_keypair.secret_key()?);
         let _ = safe
@@ -374,7 +374,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_test_coins_balance_pk() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let preload_amount = "1.154200000";
         let (_, keypair) = safe.keys_create_preload_test_coins(preload_amount).await?;
         let current_balance = safe.keys_balance_from_sk(keypair.secret_key()?).await?;
@@ -384,7 +384,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_test_coins_balance_xorurl() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let preload_amount = "0.243000000";
         let (xorurl, keypair) = safe.keys_create_preload_test_coins(preload_amount).await?;
         let current_balance = safe
@@ -396,7 +396,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_test_coins_balance_wrong_url() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let (_, keypair) = safe.keys_create_preload_test_coins("0").await?;
 
         let invalid_xorurl = "safe://this-is-not-a-valid-xor-url";
@@ -415,7 +415,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_test_coins_balance_wrong_location() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let amount = "35312.000000000";
         let (xorurl, keypair) = safe.keys_create_preload_test_coins(amount).await?;
 
@@ -443,7 +443,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_test_coins_balance_wrong_sk() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let (xorurl, _) = safe.keys_create_preload_test_coins("0").await?;
 
         let mut rng = OsRng;
@@ -461,7 +461,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_balance_pk() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let preload_amount = "1743.234";
         let (_, from_keypair) = safe.keys_create_preload_test_coins(preload_amount).await?;
         let from_sk_hex = sk_to_hex(from_keypair.secret_key()?);
@@ -486,7 +486,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_balance_xorname() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let preload_amount = "435.34";
         let (from_xorname, from_keypair) =
             safe.keys_create_preload_test_coins(preload_amount).await?;
@@ -514,7 +514,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_validate_sk_for_url() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let (xorurl, keypair) = safe.keys_create_preload_test_coins("23.22").await?;
         let pk = safe
             .validate_sk_for_url(&keypair.secret_key()?, &xorurl)
@@ -525,7 +525,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_transfer_from_zero_balance() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let (_, keypair1) = safe.keys_create_preload_test_coins("0.0").await?;
         let from_sk1_hex = sk_to_hex(keypair1.secret_key()?);
         let (to_safekey_xorurl, _keypair2) = safe.keys_create_preload_test_coins("0.5").await?;
@@ -546,7 +546,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_transfer_diff_amounts() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
         let (safekey1_xorurl, keypair1) = safe.keys_create_preload_test_coins("0.5").await?;
         let from_sk1_hex = sk_to_hex(keypair1.secret_key()?);
 
@@ -687,7 +687,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_keys_transfer_to_pk() -> Result<()> {
-        let mut safe = new_safe_instance().await?;
+        let safe = new_safe_instance().await?;
 
         let (_, keypair1) = safe.keys_create_preload_test_coins("0.136").await?;
         let from_sk1_hex = sk_to_hex(keypair1.secret_key()?);

--- a/sn_api/src/api/app/nrs/mod.rs
+++ b/sn_api/src/api/app/nrs/mod.rs
@@ -40,7 +40,7 @@ impl Safe {
     // this second SafeUrl instance contains the information of the parsed NRS-URL.
     // *Note* this is not part of the public API, but an internal helper function used by API impl.
     pub(crate) async fn parse_and_resolve_url(
-        &mut self,
+        &self,
         url: &str,
     ) -> Result<(SafeUrl, Option<SafeUrl>)> {
         let safe_url = Safe::parse_url(url)?;
@@ -240,7 +240,7 @@ impl Safe {
     ///     assert_eq!(nrs_map_container.get_default_link().unwrap(), file_xorurl);
     /// # });
     /// ```
-    pub async fn nrs_map_container_get(&mut self, url: &str) -> Result<(u64, NrsMap)> {
+    pub async fn nrs_map_container_get(&self, url: &str) -> Result<(u64, NrsMap)> {
         debug!("Getting latest resolvable map container from: {:?}", url);
         let safe_url = Safe::parse_url(url)?;
 

--- a/sn_api/src/api/app/nrs/mod.rs
+++ b/sn_api/src/api/app/nrs/mod.rs
@@ -76,7 +76,7 @@ impl Safe {
     }
 
     pub async fn nrs_map_container_add(
-        &mut self,
+        &self,
         name: &str,
         link: &str,
         default: bool,
@@ -186,7 +186,7 @@ impl Safe {
     }
 
     pub async fn nrs_map_container_remove(
-        &mut self,
+        &self,
         name: &str,
         dry_run: bool,
     ) -> Result<(u64, XorUrl, ProcessedEntries, NrsMap)> {
@@ -315,7 +315,7 @@ impl Safe {
     }
 
     // Private helper to serialise an NrsMap and store it in a Public Blob
-    async fn store_nrs_map(&mut self, nrs_map: &NrsMap) -> Result<String> {
+    async fn store_nrs_map(&self, nrs_map: &NrsMap) -> Result<String> {
         // The NrsMapContainer is a Sequence where each NRS Map version is
         // an entry containing the XOR-URL of the Blob that contains the serialised NrsMap.
         // TODO: use RDF format

--- a/sn_api/src/api/app/safe_client.rs
+++ b/sn_api/src/api/app/safe_client.rs
@@ -111,7 +111,7 @@ impl SafeAppClient {
 
     #[cfg(feature = "simulated-payouts")]
     pub async fn trigger_simulated_farming_payout(
-        &mut self,
+        &self,
         amount: Token,
         id: Option<Keypair>,
     ) -> Result<()> {

--- a/sn_api/src/api/app/sequence.rs
+++ b/sn_api/src/api/app/sequence.rs
@@ -73,7 +73,7 @@ impl Safe {
     }
 
     /// Fetch a Sequence from a SafeUrl without performing any type of URL resolution
-    pub(crate) async fn fetch_sequence(&mut self, safe_url: &SafeUrl) -> Result<(u64, Vec<u8>)> {
+    pub(crate) async fn fetch_sequence(&self, safe_url: &SafeUrl) -> Result<(u64, Vec<u8>)> {
         let is_private = safe_url.data_type() == SafeDataType::PrivateSequence;
         let data = match safe_url.content_version() {
             Some(version) => {

--- a/sn_api/src/api/app/wallet.rs
+++ b/sn_api/src/api/app/wallet.rs
@@ -210,7 +210,7 @@ impl Safe {
     }
 
     pub async fn wallet_get_default_balance(
-        &mut self,
+        &self,
         url: &str,
     ) -> Result<(WalletSpendableBalance, u64)> {
         let (safeurl, _) = self.parse_and_resolve_url(url).await?;
@@ -370,7 +370,7 @@ impl Safe {
 
     /// Fetch a Wallet from a SafeUrl without performing any type of URL resolution
     pub(crate) async fn fetch_wallet(
-        &mut self,
+        &self,
         safeurl: &SafeUrl,
     ) -> Result<WalletSpendableBalances> {
         gen_wallet_spendable_balances_list(
@@ -385,7 +385,7 @@ impl Safe {
 
 // Private helper to generate the list of SpendableBalances which is used for different purposes
 async fn gen_wallet_spendable_balances_list(
-    safe: &mut Safe,
+    safe: &Safe,
     xorname: XorName,
     type_tag: u64,
     url: &str,
@@ -446,7 +446,7 @@ async fn gen_wallet_spendable_balances_list(
 // Private helper to fetch a specific spendable balance from a Wallet usng its assigned frienly name
 // TODO: move this out to a WalletRdf API
 async fn wallet_get_spendable_balance(
-    safe: &mut Safe,
+    safe: &Safe,
     xorname: XorName,
     type_tag: u64,
     balance_name: &[u8],

--- a/sn_api/src/api/app/wallet.rs
+++ b/sn_api/src/api/app/wallet.rs
@@ -369,10 +369,7 @@ impl Safe {
     }
 
     /// Fetch a Wallet from a SafeUrl without performing any type of URL resolution
-    pub(crate) async fn fetch_wallet(
-        &self,
-        safeurl: &SafeUrl,
-    ) -> Result<WalletSpendableBalances> {
+    pub(crate) async fn fetch_wallet(&self, safeurl: &SafeUrl) -> Result<WalletSpendableBalances> {
         gen_wallet_spendable_balances_list(
             self,
             safeurl.xorname(),


### PR DESCRIPTION
Tweaked a few method signatures to leave out the mutability binding.
This means there can be multiple (immutable) references, instead of
one unique reference to the Safe instance.

(This is more of a question of whether this is something we want. I do not think there is a reason to have this being mutable, but if so, then this PR is also a commitment to the future to keep the API such that the instance can be borrowed immutably and therefore there can be multiple references at the same time. This might allow for easier usage in async contexts. This PR might serve as a draft to make sure as much of the API as possible aligns with these changes I've made mainly in keys.rs.)

<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share Map
    request for non-existent Map

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
