### PR TITLE
refactor: Adds bin-version subcommand to node & auth, removes -V for subcommands

### DIFF
--- a/sn_cli/subcommands/auth.rs
+++ b/sn_cli/subcommands/auth.rs
@@ -18,7 +18,7 @@ const AUTH_REQ_NOTIFS_ENDPOINT: &str = "https://localhost:33002";
 #[derive(StructOpt, Debug)]
 pub enum AuthSubCommands {
     /// Shows the version of the Authenticator binary
-    Version {
+    BinVersion {
         #[structopt(long = "authd-path")]
         /// Path of sn_authd executable (default ~/.safe/authd/)
         authd_path: Option<String>,
@@ -134,7 +134,7 @@ pub async fn auth_commander(
     safe: &mut Safe,
 ) -> Result<()> {
     match cmd {
-        Some(AuthSubCommands::Version {authd_path}) => {
+        Some(AuthSubCommands::BinVersion {authd_path}) => {
             let sn_authd = SafeAuthdClient::new(endpoint);
             authd_version(&sn_authd, authd_path)
         }

--- a/sn_cli/subcommands/mod.rs
+++ b/sn_cli/subcommands/mod.rs
@@ -25,7 +25,7 @@ pub mod update;
 pub mod wallet;
 pub mod xorurl;
 
-use structopt::StructOpt;
+use structopt::{clap::AppSettings, StructOpt};
 
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum OutputFmt {
@@ -54,52 +54,100 @@ impl std::str::FromStr for OutputFmt {
 
 #[derive(StructOpt, Debug)]
 pub enum SubCommands {
-    #[structopt(name = "config")]
+    #[structopt(
+        name = "config",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// CLI config settings
     Config {
         /// subcommands
         #[structopt(subcommand)]
         cmd: Option<config::ConfigSubCommands>,
     },
-    #[structopt(name = "networks")]
+    #[structopt(
+        name = "networks",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Switch between SAFE networks
     Networks {
         /// subcommands
         #[structopt(subcommand)]
         cmd: Option<networks::NetworksSubCommands>,
     },
-    #[structopt(name = "auth")]
+    #[structopt(
+        name = "auth", 
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Authorise the SAFE CLI and interact with a remote Authenticator daemon
     Auth {
         /// subcommands
         #[structopt(subcommand)]
         cmd: Option<auth::AuthSubCommands>,
     },
-    #[structopt(name = "cat")]
+    #[structopt(
+        name = "cat",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Read data on the SAFE Network
     Cat(cat::CatCommands),
-    #[structopt(name = "dog")]
+    #[structopt(
+        name = "dog",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Inspect data on the SAFE Network providing only metadata information about the content
     Dog(dog::DogCommands),
-    #[structopt(name = "files")]
+    #[structopt(
+        name = "files",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Manage files on the SAFE Network
     Files(files::FilesSubCommands),
-    #[structopt(name = "setup")]
+    #[structopt(
+        name = "setup", 
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Perform setup tasks
     Setup(setup::SetupSubCommands),
-    #[structopt(name = "keypair")]
+    #[structopt(
+        name = "keypair",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Generate a key pair without creating and/or storing a SafeKey on the network
     Keypair {},
-    #[structopt(name = "nrs")]
+    #[structopt(
+        name = "nrs",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Manage public names on the SAFE Network
     Nrs(nrs::NrsSubCommands),
-    #[structopt(name = "keys")]
+    #[structopt(
+        name = "keys",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Manage keys on the SAFE Network
     Keys(keys::KeysSubCommands),
-    #[structopt(name = "wallet")]
+    #[structopt(
+        name = "wallet",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Manage wallets on the SAFE Network
     Wallet(wallet::WalletSubCommands),
-    #[structopt(name = "xorurl")]
+    #[structopt(
+        name = "xorurl",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Obtain the XOR-URL of data without uploading it to the network, or decode XOR-URLs
     Xorurl {
         /// subcommands
@@ -114,16 +162,28 @@ pub enum SubCommands {
         #[structopt(short = "l", long = "follow-links")]
         follow_links: bool,
     },
-    #[structopt(name = "seq")]
+    #[structopt(
+        name = "seq",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Manage Sequences on the Safe Network
     Seq(seq::SeqSubCommands),
     // #[structopt(name = "safe-id")]
     // /// Manage identities on the Safe Network
     // SafeId(safe_id::SafeIdSubCommands),
-    #[structopt(name = "update")]
+    #[structopt(
+        name = "update",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Update the application to the latest available version
     Update {},
-    #[structopt(name = "node")]
+    #[structopt(
+        name = "node",
+        no_version,
+        global_settings(&[AppSettings::DisableVersion]),
+    )]
     /// Commands to manage Safe Network Nodes
     Node {
         /// subcommands

--- a/sn_cli/subcommands/node.rs
+++ b/sn_cli/subcommands/node.rs
@@ -22,6 +22,11 @@ const LOCAL_NODE_DIR: &str = "local-node";
 
 #[derive(StructOpt, Debug)]
 pub enum NodeSubCommands {
+    /// Gets the version of `sn_node` binary
+    BinVersion {
+        #[structopt(long = "node_path", env = "SN_NODE_PATH")]
+        node_path: Option<PathBuf>,
+    },
     #[structopt(name = "install")]
     /// Install latest sn_node released version in the system
     Install {
@@ -87,6 +92,7 @@ pub enum NodeSubCommands {
 
 pub async fn node_commander(cmd: Option<NodeSubCommands>) -> Result<()> {
     match cmd {
+        Some(NodeSubCommands::BinVersion { node_path }) => node_version(node_path),
         Some(NodeSubCommands::Install { node_path }) => {
             // We run this command in a separate thread to overcome a conflict with
             // the self_update crate as it seems to be creating its own runtime.


### PR DESCRIPTION
Fixes #611 

See forum thread [here](https://forum.safedev.org/t/what-can-i-do-to-help/2965) for discussion, but it doesn't "fix" the behavior as might be suggested in the git issue.

The idea is that subcommands in our binary aren't versioned explicitly, so this patch removes the `-V` option when subcommands are supplied to avoid confusion between subcommand version (which we don't really support) and the version of external binaries like `sn_node`. Then this also adds a `bin-version` subcommand to `node` and `auth` to fetch the version of the external binary, so that the semantics are clearer as well as the distinction between the `cli` version and `sn_node` and `sn_authd` versions.