### PR TITLE
feat(jsonrpc): adds spec-defined error code constants

### DIFF
--- a/qjsonrpc/src/jsonrpc.rs
+++ b/qjsonrpc/src/jsonrpc.rs
@@ -20,6 +20,15 @@ const SN_AUTHD_JSONRPC_VERSION: &str = "2.0";
 const JSONRPC_PARSE_ERROR: isize = -32700;
 const JSONRPC_INVALID_REQUEST: isize = -32600;
 
+/// Spec-defined code for method not found
+pub const JSONRPC_METHOD_NOT_FOUND: isize = -32601;
+
+/// Spec-defined code for invalid method params
+pub const JSONRPC_INVALID_PARAMS: isize = -32602;
+
+/// Spec-defined catch-all error to use as a fallback
+pub const JSONRPC_INTERNAL_ERROR: isize = -32603;
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct JsonRpcRequest {
     jsonrpc: String,

--- a/qjsonrpc/src/lib.rs
+++ b/qjsonrpc/src/lib.rs
@@ -19,4 +19,7 @@ pub use client_endpoint::ClientEndpoint;
 pub use errors::{Error, Result};
 pub use server_endpoint::{Endpoint, IncomingConn, IncomingJsonRpcRequest, JsonRpcResponseStream};
 
-pub use jsonrpc::{JsonRpcRequest, JsonRpcResponse};
+pub use jsonrpc::{
+    JsonRpcRequest, JsonRpcResponse, JSONRPC_INTERNAL_ERROR, JSONRPC_INVALID_PARAMS,
+    JSONRPC_METHOD_NOT_FOUND,
+};


### PR DESCRIPTION
Closes #730 

This patch would expose several useful spec-defined error codes in the `qjsonrpc` crate.