### PR TITLE
chore(ci): re-enabling sn_api tests in CI

### DIFF
--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -15,7 +15,6 @@ jobs:
     # if: ${{ github.repository_owner == 'maidsafe' }}
     name: E2E against real network
     runs-on: ubuntu-latest
-    if: false
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
@@ -32,8 +31,8 @@ jobs:
         run: cargo build --release
       - name: Setup Safe Cli and PATH etc
         run: |
-          mkdir -p ~/.safe/cli
-          mkdir -p ~/.safe/authd
+          mkdir -p $HOME/.safe/cli
+          mkdir -p $HOME/.safe/authd
           cp ./target/release/safe $HOME/.safe/cli/
           cp ./target/release/sn_authd $HOME/.safe/authd/
           ls $HOME/.safe/cli
@@ -48,6 +47,7 @@ jobs:
         run : safe node run-baby-fleming -t
 
       - name: Run CLI Tests
+        if: false
         run: ./resources/test-scripts/cli-tests
         shell: bash
 

--- a/resources/test-scripts/api-tests
+++ b/resources/test-scripts/api-tests
@@ -8,6 +8,8 @@ function run_api_tests() {
     #cargo test --release --lib -- --test-threads=1
     cargo test --release test_sequence_ -- --test-threads=1
     cargo test --release test_fetch_ -- --test-threads=1
+    cargo test --release test_keys_ -- --test-threads=1
+    cargo test --release test_safeurl_ -- --test-threads=1
     cd -
 }
 

--- a/resources/test-scripts/api-tests
+++ b/resources/test-scripts/api-tests
@@ -10,6 +10,7 @@ function run_api_tests() {
     cargo test --release test_fetch_ -- --test-threads=1
     cargo test --release test_keys_ -- --test-threads=1
     cargo test --release test_safeurl_ -- --test-threads=1
+    cargo test --release test_wallet_ -- --test-threads=1
     cd -
 }
 

--- a/resources/test-scripts/api-tests
+++ b/resources/test-scripts/api-tests
@@ -4,8 +4,10 @@ set -e -x
 
 function run_api_tests() {
     cd sn_api
-    TEST_AUTH_CREDENTIALS=$(cat ~/.safe/cli/credentials)
-    cargo test --release --lib --features=simulated-payouts -- --test-threads=1
+    export TEST_AUTH_CREDENTIALS=$(cat ~/.safe/cli/credentials)
+    #cargo test --release --lib -- --test-threads=1
+    cargo test --release test_sequence_ -- --test-threads=1
+    cargo test --release test_fetch_ -- --test-threads=1
     cd -
 }
 

--- a/sn_api/src/api/app/mod.rs
+++ b/sn_api/src/api/app/mod.rs
@@ -18,7 +18,7 @@ mod sequence;
 mod test_helpers;
 mod xorurl_media_types;
 
-use super::{common, constants};
+use super::{common, constants, Result};
 use rand::rngs::OsRng;
 use safe_client::SafeAppClient;
 use std::time::Duration;
@@ -69,5 +69,11 @@ impl Safe {
     pub fn keypair(&self) -> Keypair {
         let mut rng = OsRng;
         Keypair::new_ed25519(&mut rng)
+    }
+
+    /// Retrieve the keypair this instance was instantiated with, i.e. the
+    /// keypair this instance uses by default to sign each outgoing message
+    pub async fn get_my_keypair(&self) -> Result<Keypair> {
+        self.safe_client.keypair().await
     }
 }

--- a/sn_api/src/api/app/safe_client.rs
+++ b/sn_api/src/api/app/safe_client.rs
@@ -88,6 +88,11 @@ impl SafeAppClient {
         Ok(())
     }
 
+    pub async fn keypair(&self) -> Result<Keypair> {
+        let client = self.get_safe_client()?;
+        Ok(client.keypair().await)
+    }
+
     // === Token operations ===
     pub async fn read_balance_from_keypair(&self, id: Keypair) -> Result<Token> {
         let temp_client = Client::new(

--- a/sn_api/src/api/app/safe_client.rs
+++ b/sn_api/src/api/app/safe_client.rs
@@ -176,6 +176,9 @@ impl SafeAppClient {
                 .send_tokens(to_pk, amount)
                 .await
                 .map_err(|err| match err {
+                    ClientError::Transfer(TransfersError::ZeroValueTransfer) => {
+                        Error::InvalidAmount("Cannot send zero-value transfers".to_string())
+                    }
                     ClientError::Transfer(TransfersError::InsufficientBalance) => {
                         Error::NotEnoughBalance(format!(
                             "Not enough balance at 'source' for the operation: {}",

--- a/sn_api/src/api/app/safe_client.rs
+++ b/sn_api/src/api/app/safe_client.rs
@@ -10,7 +10,7 @@
 use super::{fetch::Range, helpers::xorname_to_hex};
 use crate::{api::ipc::BootstrapConfig, Error, Result};
 use log::{debug, info};
-use sn_client::{Client, Error as ClientError, TransfersError};
+use sn_client::{Client, Error as ClientError, ErrorMessage, TransfersError};
 use sn_data_types::{
     BlobAddress, Error as SafeNdError, Keypair, Map, MapAction, MapAddress, MapEntryActions,
     MapPermissionSet, MapSeqEntryActions, MapSeqValue, MapValue, PublicKey, SequenceAddress,
@@ -309,7 +309,8 @@ impl SafeAppClient {
             .get_map_value(address, key_vec)
             .await
             .map_err(|err| match err {
-                ClientError::NetworkDataError(SafeNdError::AccessDenied(_pk)) => {
+                ClientError::ErrorMessage(ErrorMessage::AccessDenied(_pk))
+                | ClientError::NetworkDataError(SafeNdError::AccessDenied(_pk)) => {
                     Error::AccessDenied(format!("Failed to retrieve a key: {:?}", key))
                 }
                 // FIXME: we need to match the appropriate error

--- a/sn_api/src/api/app/test_helpers.rs
+++ b/sn_api/src/api/app/test_helpers.rs
@@ -9,8 +9,7 @@
 
 use crate::Safe;
 use anyhow::{Context, Result};
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use std::{collections::HashSet, env::var, net::SocketAddr};
 
 // Environment variable which can be set with the auth credentials
@@ -71,4 +70,16 @@ fn get_bootstrap_contacts() -> Result<HashSet<SocketAddr>> {
     };
 
     Ok(contacts)
+}
+
+#[macro_export]
+macro_rules! retry_loop {
+    ($async_func:expr) => {
+        loop {
+            match $async_func.await {
+                Ok(val) => break val,
+                Err(_) => tokio::time::delay_for(std::time::Duration::from_millis(200)).await,
+            }
+        }
+    };
 }

--- a/sn_api/src/api/app/test_helpers.rs
+++ b/sn_api/src/api/app/test_helpers.rs
@@ -83,3 +83,16 @@ macro_rules! retry_loop {
         }
     };
 }
+
+#[macro_export]
+macro_rules! retry_loop_for_pattern {
+    ($async_func:expr, $pattern:pat $(if $cond:expr)?) => {
+        loop {
+            let result = $async_func.await;
+            match &result {
+                $pattern $(if $cond)? => break result,
+                Ok(_) | Err(_) => tokio::time::delay_for(std::time::Duration::from_millis(200)).await,
+            }
+        }
+    };
+}


### PR DESCRIPTION
This re-enables running sn_api tests in CI, but here only a first subset of all tests is enabled, those for the following APIs:
- fetch
- sequence
- xorurl
- keys
- wallet

Also, one wallet tests is being for now skipped as there seems to be a bug in the network for Map inserts, which will be investigated and when fixed this test can be enabled too.