### PR TITLE
Use traits to make API more interoperable

### DIFF
--- a/sn_api/src/api/app/fetch.rs
+++ b/sn_api/src/api/app/fetch.rs
@@ -894,7 +894,9 @@ mod tests {
     async fn test_fetch_public_sequence() -> Result<()> {
         let mut safe = new_safe_instance().await?;
         let data = b"Something super immutable";
-        let xorurl = safe.sequence_create(data, None, 25_000, false).await?;
+        let xorurl = safe
+            .sequence_create(data as &[u8], None, 25_000, false)
+            .await?;
 
         let safe_url = SafeUrl::from_url(&xorurl)?;
         let content = retry_loop!(safe.fetch(&xorurl, None));

--- a/sn_api/src/api/app/sequence.rs
+++ b/sn_api/src/api/app/sequence.rs
@@ -30,9 +30,9 @@ impl Safe {
     ///     assert_eq!(received_data, (0, data.to_vec()));
     /// # });
     /// ```
-    pub async fn sequence_create(
+    pub async fn sequence_create<R: std::io::Read>(
         &mut self,
-        data: &[u8],
+        data: R,
         name: Option<XorName>,
         type_tag: u64,
         private: bool,
@@ -163,10 +163,10 @@ mod tests {
         let initial_data = b"initial data";
 
         let xorurl = safe
-            .sequence_create(initial_data, None, 25_000, false)
+            .sequence_create(initial_data as &[u8], None, 25_000, false)
             .await?;
         let xorurl_priv = safe
-            .sequence_create(initial_data, None, 25_000, true)
+            .sequence_create(initial_data as &[u8], None, 25_000, true)
             .await?;
 
         let received_data = retry_loop!(safe.sequence_get(&xorurl));
@@ -182,8 +182,12 @@ mod tests {
         let data_v0 = b"First in the sequence";
         let data_v1 = b"Second in the sequence";
 
-        let xorurl = safe.sequence_create(data_v0, None, 25_000, false).await?;
-        let xorurl_priv = safe.sequence_create(data_v0, None, 25_000, true).await?;
+        let xorurl = safe
+            .sequence_create(data_v0 as &[u8], None, 25_000, false)
+            .await?;
+        let xorurl_priv = safe
+            .sequence_create(data_v0 as &[u8], None, 25_000, true)
+            .await?;
 
         let _ = retry_loop!(safe.sequence_get(&xorurl));
         safe.append_to_sequence(&xorurl, data_v1).await?;
@@ -210,7 +214,7 @@ mod tests {
         let data_v1 = b"Second in the sequence";
 
         let xorurl = client1
-            .sequence_create(data_v0, None, 25_000, false)
+            .sequence_create(data_v0 as &[u8], None, 25_000, false)
             .await?;
         let _ = retry_loop!(client1.sequence_get(&xorurl));
         client1.append_to_sequence(&xorurl, data_v1).await?;
@@ -238,7 +242,7 @@ mod tests {
         let data_v1 = b"First from client2";
 
         let xorurl = client1
-            .sequence_create(data_v0, None, 25_000, false)
+            .sequence_create(data_v0 as &[u8], None, 25_000, false)
             .await?;
 
         let received_client1 = retry_loop!(client1.sequence_get(&xorurl));

--- a/sn_cli/subcommands/seq.rs
+++ b/sn_cli/subcommands/seq.rs
@@ -69,7 +69,8 @@ pub async fn seq_commander(
             // If data is '-' then we read arg from STDIN
             let xorurl = if data == "-" {
                 safe.sequence_create(
-                    &get_from_stdin(Some("...awaiting data that will be stored from STDIN"))?,
+                    get_from_stdin(Some("...awaiting data that will be stored from STDIN"))?
+                        .as_slice(),
                     xorname,
                     tag,
                     private,


### PR DESCRIPTION
One of the things making a good API is using trait bounds to accept a broader range of inputs. One such case is accepting `std::io::Read` so that multiple types can be passed, like slices and `File`s.

Feedback is welcome, there are a lot of places that can be improved in this regard.
<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share Map
    request for non-existent Map

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
