### PR TITLE
feat(cli): log format matches sn_node log format

### DIFF
--- a/sn_cli/Cargo.toml
+++ b/sn_cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "main.rs"
 [dependencies]
 ansi_term = "~0.12.1"
 async-std = "1.9.0"
+chrono = "0.4.19"
 dirs-next = "2.0.0"
 env_logger = "~0.8.3"
 envy = "~0.4.2"

--- a/sn_cli/main.rs
+++ b/sn_cli/main.rs
@@ -13,9 +13,11 @@ mod shell;
 mod subcommands;
 
 use anyhow::Result;
+use chrono::Local;
 use cli::run;
 use human_panic::{handle_dump, Metadata};
 use log::debug;
+use std::io::Write;
 use std::panic::set_hook;
 
 #[macro_use]
@@ -29,7 +31,21 @@ const APP_VENDOR: &str = "MaidSafe.net Ltd";
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::init();
+    let mut builder = env_logger::Builder::from_default_env();
+    builder
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "[{}] {} {} [{}:{}] {}",
+                record.module_path().unwrap_or(""),
+                record.level(),
+                Local::now().format("%Y-%m-%dT%H:%M:%S.%f"),
+                record.file().unwrap_or_default(),
+                record.line().unwrap_or_default(),
+                record.args()
+            )
+        })
+        .init();
     debug!("Starting Safe CLI...");
 
     // We register our own panic hook to customise the error message displayed,


### PR DESCRIPTION
[module_path] level time [file:line] args
See
https://github.com/maidsafe/sn_node/blob/de12c4d36c63451ed5283d98d0989fcac224b937/src/utils.rs#L60-L76
for matching sn_node log format

I appreciate the cli logs form part of the user experience so this format may not suit the desired ux. My reason for the pull request is so node logs and cli logs can both be parsed the same way by a log visualizer.
