### PR TITLE
feat: pass SecretKey by reference

### DIFF
--- a/sn_api/src/api/app/keys.rs
+++ b/sn_api/src/api/app/keys.rs
@@ -96,7 +96,7 @@ impl Safe {
     }
 
     // Check SafeKey's balance from the network from a given SecretKey string
-    pub async fn keys_balance_from_sk(&self, secret_key: SecretKey) -> Result<String> {
+    pub async fn keys_balance_from_sk(&self, secret_key: &SecretKey) -> Result<String> {
         let keypair = match secret_key {
             SecretKey::Ed25519(sk) => {
                 let bytes = sk.to_bytes();
@@ -126,7 +126,7 @@ impl Safe {
         secret_key: SecretKey,
     ) -> Result<String> {
         self.validate_sk_for_url(&secret_key, url).await?;
-        self.keys_balance_from_sk(secret_key).await
+        self.keys_balance_from_sk(&secret_key).await
     }
 
     // Check that the XOR/NRS-URL corresponds to the public key derived from the provided client id
@@ -282,7 +282,7 @@ mod tests {
         let (_, keypair) = safe
             .keys_create_and_preload_from_sk_string(&from_sk_hex, preload_amount)
             .await?;
-        let balance = safe.keys_balance_from_sk(keypair.secret_key()?).await?;
+        let balance = safe.keys_balance_from_sk(&keypair.secret_key()?).await?;
         assert_eq!(balance, preload_amount);
         Ok(())
     }
@@ -373,7 +373,7 @@ mod tests {
         let mut safe = new_safe_instance().await?;
         let preload_amount = "1.154200000";
         let (_, keypair) = safe.keys_create_preload_test_coins(preload_amount).await?;
-        let current_balance = safe.keys_balance_from_sk(keypair.secret_key()?).await?;
+        let current_balance = safe.keys_balance_from_sk(&keypair.secret_key()?).await?;
         assert_eq!(preload_amount, current_balance);
         Ok(())
     }
@@ -468,14 +468,14 @@ mod tests {
             .await?;
 
         let from_current_balance = safe
-            .keys_balance_from_sk(from_keypair.secret_key()?)
+            .keys_balance_from_sk(&from_keypair.secret_key()?)
             .await?;
         assert_eq!(
             "3.234000000", /*== 1743.234 - 1740 */
             from_current_balance
         );
 
-        let to_current_balance = safe.keys_balance_from_sk(to_keypair.secret_key()?).await?;
+        let to_current_balance = safe.keys_balance_from_sk(&to_keypair.secret_key()?).await?;
         assert_eq!(amount, to_current_balance);
         Ok(())
     }
@@ -602,9 +602,9 @@ mod tests {
             Err(msg) => Err(anyhow!("Transfer was expected to succeed: {}", msg)),
             Ok(_) => {
                 let from_current_balance =
-                    safe.keys_balance_from_sk(keypair2.secret_key()?).await?;
+                    safe.keys_balance_from_sk(&keypair2.secret_key()?).await?;
                 assert_eq!("0.100000000", from_current_balance);
-                let to_current_balance = safe.keys_balance_from_sk(keypair1.secret_key()?).await?;
+                let to_current_balance = safe.keys_balance_from_sk(&keypair1.secret_key()?).await?;
                 assert_eq!("100.900000000", to_current_balance);
                 Ok(())
             }
@@ -636,7 +636,7 @@ mod tests {
             Err(msg) => Err(anyhow!("Transfer was expected to succeed: {}", msg)),
             Ok(_) => {
                 let from_current_balance =
-                    safe.keys_balance_from_sk(keypair2.secret_key()?).await?;
+                    safe.keys_balance_from_sk(&keypair2.secret_key()?).await?;
                 assert_eq!(
                     "4097.580000000", /* 4621.45 - 523.87 */
                     from_current_balance
@@ -672,10 +672,10 @@ mod tests {
             )
             .await?;
 
-        let from_current_balance = safe.keys_balance_from_sk(keypair1.secret_key()?).await?;
+        let from_current_balance = safe.keys_balance_from_sk(&keypair1.secret_key()?).await?;
         assert_eq!("0.000000000" /* 0.2 - 0.2 */, from_current_balance);
 
-        let to_current_balance = safe.keys_balance_from_sk(keypair2.secret_key()?).await?;
+        let to_current_balance = safe.keys_balance_from_sk(&keypair2.secret_key()?).await?;
         assert_eq!("0.300000000" /* 0.1 + 0.2 */, to_current_balance);
 
         Ok(())
@@ -695,10 +695,10 @@ mod tests {
             .keys_transfer("0.111", Some(&from_sk1_hex), &to_pk2_hex)
             .await?;
 
-        let from_current_balance = safe.keys_balance_from_sk(keypair1.secret_key()?).await?;
+        let from_current_balance = safe.keys_balance_from_sk(&keypair1.secret_key()?).await?;
         assert_eq!("0.025000000" /* 0.136 - 0.111 */, from_current_balance);
 
-        let to_current_balance = safe.keys_balance_from_sk(keypair2.secret_key()?).await?;
+        let to_current_balance = safe.keys_balance_from_sk(&keypair2.secret_key()?).await?;
         assert_eq!("0.841000000" /* 0.73 + 0.111 */, to_current_balance);
 
         Ok(())

--- a/sn_api/src/api/app/wallet.rs
+++ b/sn_api/src/api/app/wallet.rs
@@ -872,7 +872,8 @@ mod tests {
                     "4097.580000000", /* 4621.45 - 523.87 */
                     from_current_balance
                 );
-                let key_current_balance = safe.keys_balance_from_sk(&keypair3.secret_key()?).await?;
+                let key_current_balance =
+                    safe.keys_balance_from_sk(&keypair3.secret_key()?).await?;
                 assert_eq!("533.870000000", key_current_balance);
                 Ok(())
             }
@@ -909,7 +910,8 @@ mod tests {
                     "565.060000000", /* 1122.98 - 557.92 */
                     from_current_balance
                 );
-                let key_current_balance = safe.keys_balance_from_sk(&keypair2.secret_key()?).await?;
+                let key_current_balance =
+                    safe.keys_balance_from_sk(&keypair2.secret_key()?).await?;
                 assert_eq!(
                     "3789.920000000", /* 3232 + 557.92 */
                     key_current_balance
@@ -982,7 +984,8 @@ mod tests {
             Ok(_) => {
                 let from_current_balance = safe.wallet_balance(&from_nrs_url).await?;
                 assert_eq!("0.000000000" /* 0.2 - 0.2 */, from_current_balance);
-                let key_current_balance = safe.keys_balance_from_sk(&keypair3.secret_key()?).await?;
+                let key_current_balance =
+                    safe.keys_balance_from_sk(&keypair3.secret_key()?).await?;
                 assert_eq!("0.300000000" /* 0.1 + 0.2 */, key_current_balance);
                 Ok(())
             }

--- a/sn_api/src/api/app/wallet.rs
+++ b/sn_api/src/api/app/wallet.rs
@@ -872,7 +872,7 @@ mod tests {
                     "4097.580000000", /* 4621.45 - 523.87 */
                     from_current_balance
                 );
-                let key_current_balance = safe.keys_balance_from_sk(keypair3.secret_key()?).await?;
+                let key_current_balance = safe.keys_balance_from_sk(&keypair3.secret_key()?).await?;
                 assert_eq!("533.870000000", key_current_balance);
                 Ok(())
             }
@@ -909,7 +909,7 @@ mod tests {
                     "565.060000000", /* 1122.98 - 557.92 */
                     from_current_balance
                 );
-                let key_current_balance = safe.keys_balance_from_sk(keypair2.secret_key()?).await?;
+                let key_current_balance = safe.keys_balance_from_sk(&keypair2.secret_key()?).await?;
                 assert_eq!(
                     "3789.920000000", /* 3232 + 557.92 */
                     key_current_balance
@@ -982,7 +982,7 @@ mod tests {
             Ok(_) => {
                 let from_current_balance = safe.wallet_balance(&from_nrs_url).await?;
                 assert_eq!("0.000000000" /* 0.2 - 0.2 */, from_current_balance);
-                let key_current_balance = safe.keys_balance_from_sk(keypair3.secret_key()?).await?;
+                let key_current_balance = safe.keys_balance_from_sk(&keypair3.secret_key()?).await?;
                 assert_eq!("0.300000000" /* 0.1 + 0.2 */, key_current_balance);
                 Ok(())
             }

--- a/sn_cli/subcommands/keys.rs
+++ b/sn_cli/subcommands/keys.rs
@@ -110,7 +110,7 @@ pub async fn key_commander(
             };
 
             let current_balance = if target.is_empty() {
-                safe.keys_balance_from_sk(sk).await
+                safe.keys_balance_from_sk(&sk).await
             } else {
                 safe.keys_balance_from_url(&target, sk).await
             }?;


### PR DESCRIPTION
Prevent unnecessary cloning (which SecretKey doesn't even allow) to pass SecretKey to get balance from key.