### PR TITLE
Retry loopn

### DIFF
--- a/src/app/test_helpers.rs
+++ b/src/app/test_helpers.rs
@@ -75,25 +75,25 @@ fn read_default_peers_from_file() -> Result<HashSet<SocketAddr>> {
         ),
         Some(mut paths) => {
             paths.push(DEFAULT_PEER_FILE_IN_HOME);
-            paths.display().to_string()
+            paths
         }
     };
 
     let raw_json = fs::read_to_string(&default_peer_file).with_context(|| {
         format!(
-            "Failed to read bootstraping contacts list from file: {}",
+            "Failed to read bootstraping contacts list from file: {:?}",
             &default_peer_file
         )
     })?;
-    let urls: Vec<String> = serde_json::from_str(&raw_json).with_context(|| {
+
+    let sockaddrs: HashSet<SocketAddr> = serde_json::from_str(&raw_json).with_context(|| {
         format!(
-            "Failed to parse bootstraping contacts list from file: {}",
+            "Failed to parse bootstraping contacts list from file: {:?}",
             &default_peer_file
         )
     })?;
-    let sockaddrs: Result<HashSet<SocketAddr>, std::net::AddrParseError> =
-        urls.iter().map(|u| u.parse()).collect();
-    Ok(sockaddrs?)
+
+    Ok(sockaddrs)
 }
 
 fn get_bootstrap_contacts() -> Result<HashSet<SocketAddr>> {


### PR DESCRIPTION
<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share Map
    request for non-existent Map

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->

This is an attempt to fix the hanging tests that use the retry_loop! macro which loops indefinitely, making tests hang and hiding the repeating error.
This is my proposal for a fix: it retries a given number of times (defaults to 10 if n is not provided) and bails after retrying those n times.
Along with small style improvements in test helpers. 